### PR TITLE
[notification] fix notification can expandable

### DIFF
--- a/pushdy/src/main/java/com/pushdy/handlers/PDYNotificationHandler.kt
+++ b/pushdy/src/main/java/com/pushdy/handlers/PDYNotificationHandler.kt
@@ -70,6 +70,7 @@ internal class PDYNotificationHandler {
                     notificationBuilder.setSmallIcon(smallIcon!!)
                     notificationBuilder.setContentTitle(title)
                     notificationBuilder.setContentText(body)
+                    notificationBuilder.setStyle(NotificationCompat.BigTextStyle().bigText(body))
                     notificationBuilder.setAutoCancel(true)
                     notificationBuilder.setSound(soundUri)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
Fix notification text can expandable.
Image below.
current error: https://imgur.com/zTQakSJ
after fix: https://imgur.com/IIi1i1r