### PR TITLE
fix in-app banner ui notification when device in dark-mode

### DIFF
--- a/pushdy/src/main/java/com/pushdy/views/PDYNotificationView.kt
+++ b/pushdy/src/main/java/com/pushdy/views/PDYNotificationView.kt
@@ -14,6 +14,7 @@ import com.pushdy.PDYConstant
 import com.pushdy.Pushdy
 import com.pushdy.R
 import android.util.Log
+import android.widget.RelativeLayout
 import com.pushdy.core.entities.PDYParam
 import com.pushdy.handlers.PDYDownloadImageHandler
 
@@ -31,6 +32,7 @@ open class PDYNotificationView : FrameLayout, View.OnClickListener, PDYPushBanne
     private var _rootView:View? = null
     private var _badge:View? = null
     private var _onTap:(() -> Unit?)? = null
+    private var _notificationC:RelativeLayout? = null
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
@@ -42,12 +44,23 @@ open class PDYNotificationView : FrameLayout, View.OnClickListener, PDYPushBanne
         _titleTV = view.findViewById(R.id.tvTitle)
         _contentTV = view.findViewById(R.id.tvContent)
         _thumbIV = view.findViewById(R.id.ivThumb)
-
+        _notificationC = view.findViewById(R.id.notificationC)
         _badge?.setOnClickListener(this)
         val closeBtn:ImageView = view.findViewById(R.id.btnClose)
         closeBtn.setOnClickListener(OnClickListener { view ->
             hideView()
         })
+        /**
+         * Get status bar height to set layout in order to make notification below status bar.
+         */
+        var result = 0;
+        val resourceId = resources.getIdentifier("status_bar_height","dimen","android");
+        if (resourceId > 0) {
+            result = resources.getDimensionPixelSize(resourceId);
+        }
+        var layoutParams:FrameLayout.LayoutParams = FrameLayout.LayoutParams(RelativeLayout.LayoutParams.WRAP_CONTENT,RelativeLayout.LayoutParams.WRAP_CONTENT)
+        layoutParams.setMargins(0,result,0,0)
+        _notificationC!!.layoutParams = layoutParams
     }
 
     companion object {
@@ -101,6 +114,7 @@ open class PDYNotificationView : FrameLayout, View.OnClickListener, PDYPushBanne
         if (_notification!!.containsKey("title")) {
             _titleTV?.text = _notification!!["title"] as String
         }
+        Log.d("RNPushdy title:", notification["body"] as String);
         if (_notification!!.containsKey("body")) {
             _contentTV?.text = _notification!!["body"] as String
         }

--- a/pushdy/src/main/res/layout/view_in_app_banner.xml
+++ b/pushdy/src/main/res/layout/view_in_app_banner.xml
@@ -3,6 +3,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="70dp"
+        android:id="@+id/notificationC"
+        android:layout_marginTop="@*android:dimen/status_bar_height"
         android:background="@drawable/bg_line_bottom_border">
 
     <LinearLayout
@@ -41,6 +43,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="4dp"
                     android:ellipsize="end"
+                    android:textColor="#000"
                     android:maxLines="1"
                     android:text="title" />
 
@@ -49,6 +52,7 @@
                     style="@style/TextAppearance.Compat.Notification.Line2"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:textColor="#000"
                     android:ellipsize="end"
                     android:maxLines="2"
                     android:text="content" />


### PR DESCRIPTION
fix white text notification banner inside an in-app notification. (change it to white)
add margin-top in in-app notification layout in order to show notification below StatusBar 